### PR TITLE
code cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "astro dev",
     "prebuild": "node scripts/run-thumbs-if-stale.mjs",
-    "build": "astro build && node scripts/build-search-index.mjs",
+    "build": "astro build",
     "postbuild": "node scripts/check-site.mjs --dir dist",
     "preview": "astro preview",
     "astro": "astro",

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -30,9 +30,9 @@ interface Props {
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 const { title, description, image, type = 'website', author, datePublished, dateModified, keywords = [] } = Astro.props as Props;
-// Simple on/off toggle for the temporary password gate
-// Set to true to enable, false to disable
-const ENABLE_PASSWORD_GATE = false;
+// The temporary password gate is opt-in and enabled only when the public env
+// variable is set to the exact string "true".
+const ENABLE_PASSWORD_GATE = import.meta.env.PUBLIC_ENABLE_PASSWORD_GATE === 'true';
 // Optional Google Search Console verification token (URL-prefix property)
 const GOOGLE_SITE_VERIFICATION = String(import.meta.env.PUBLIC_GOOGLE_SITE_VERIFICATION || '');
 // Default OG image handling:

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,25 +1,18 @@
 ---
 import type { CollectionEntry } from 'astro:content';
-import { getCollection } from 'astro:content';
 import BaseHead from '../components/BaseHead.astro';
 import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
 import Header from '../components/Header.astro';
+import { getVisibleSortedBlogPosts, resolveBlogThumb } from '../lib/blog';
 import { tagToSlug } from '../lib/slug';
 import Comments from '../components/Comments.astro';
 
 type Props = CollectionEntry<'blog'>['data'] & { slug: string; showComments?: boolean };
 
 const { title, description, pubDate, updatedDate, slug, author, tags, showComments = true } = Astro.props as Props;
-// Map of generated SVG thumbs (url strings)
-const thumbs = import.meta.glob('../assets/thumbs/*.svg', { query: '?url', import: 'default' });
-const heroUrl = await (thumbs[`../assets/thumbs/${slug}.svg`] || thumbs[`../assets/thumbs/default.svg`])() as string;
-// Determine newer/older posts based on pubDate (desc)
-const allPosts = (await getCollection('blog'))
-  .filter((p) => (import.meta.env.PROD ? p.data.status === 'published' : true))
-  .sort(
-	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
-);
+const heroUrl = await resolveBlogThumb(slug);
+const allPosts = await getVisibleSortedBlogPosts();
 const currentIndex = allPosts.findIndex((p) => p.id === slug);
 const newerPost = currentIndex > 0 ? allPosts[currentIndex - 1] : undefined; // novší článok
 const olderPost = currentIndex >= 0 && currentIndex < allPosts.length - 1 ? allPosts[currentIndex + 1] : undefined; // starší článok

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -19,11 +19,6 @@ const {
   wrap = true,
   mainClass = 'mx-auto max-w-4xl px-4 sm:px-6 lg:px-8',
 }: Props & { sectionClass?: string; wrap?: boolean; mainClass?: string } = Astro.props;
-const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
-const resolvedImageWithDomain = new URL(
-  "/default.jpg",
-  Astro.site
-).toString();
 ---
 
 <!doctype html>

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,0 +1,37 @@
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+export type BlogEntry = CollectionEntry<'blog'>;
+
+const thumbs = import.meta.glob('../assets/thumbs/*.svg', {
+  query: '?url',
+  import: 'default',
+}) as Record<string, () => Promise<string>>;
+
+export function isVisibleBlogPost(post: BlogEntry, prod = import.meta.env.PROD): boolean {
+  return !prod || post.data.status === 'published';
+}
+
+export function getVisibleBlogPosts(posts: BlogEntry[], prod = import.meta.env.PROD): BlogEntry[] {
+  return posts.filter((post) => isVisibleBlogPost(post, prod));
+}
+
+export function sortBlogPostsByDateDesc<T extends BlogEntry>(posts: T[]): T[] {
+  return [...posts].sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+}
+
+export async function getVisibleSortedBlogPosts(prod = import.meta.env.PROD): Promise<BlogEntry[]> {
+  return sortBlogPostsByDateDesc(getVisibleBlogPosts(await getCollection('blog'), prod));
+}
+
+export async function resolveBlogThumb(id: string): Promise<string> {
+  const key = `../assets/thumbs/${id}.svg`;
+  const fallback = `../assets/thumbs/default.svg`;
+  const loader = thumbs[key] || thumbs[fallback];
+  return loader();
+}
+
+export async function withBlogThumbs<T extends { id: string }>(
+  posts: T[],
+): Promise<Array<T & { thumb: string }>> {
+  return Promise.all(posts.map(async (post) => ({ ...post, thumb: await resolveBlogThumb(post.id) })));
+}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,23 +1,10 @@
 ---
 import Page from "../layouts/Page.astro";
 import PostsGrid from "../components/PostsGrid.astro";
-import { getCollection } from "astro:content";
+import { getVisibleSortedBlogPosts, withBlogThumbs } from "../lib/blog";
 
-// Reuse homepage thumbnail loading
-const thumbs = import.meta.glob("../assets/thumbs/*.svg", { query: "?url", import: "default" });
-async function getThumb(id: string) {
-  const key = `../assets/thumbs/${id}.svg`;
-  const def = `../assets/thumbs/default.svg`;
-  const loader = (thumbs as Record<string, () => Promise<string>>)[key] || (thumbs as Record<string, () => Promise<string>>)[def];
-  return await loader();
-}
-
-const allPosts = await getCollection("blog");
-const posts = allPosts.filter((p) => (import.meta.env.PROD ? p.data.status === "published" : true));
-const latestPosts = posts
-  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
-  .slice(0, 4);
-const latestWithThumbs = await Promise.all(latestPosts.map(async (p) => ({ ...p, thumb: await getThumb(p.id) })));
+const latestPosts = (await getVisibleSortedBlogPosts()).slice(0, 4);
+const latestWithThumbs = await withBlogThumbs(latestPosts);
 ---
 
 <Page title="Táto stránka sa nenašla" description="Skús to vyhľadať, alebo si pozri najnovšie články.">

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,12 +1,10 @@
 ---
 import { type CollectionEntry, getCollection, render } from 'astro:content';
 import BlogPost from '../../layouts/BlogPost.astro';
+import { getVisibleBlogPosts } from '../../lib/blog';
 
 export async function getStaticPaths() {
-	const posts = await getCollection('blog');
-	const filtered = import.meta.env.PROD
-		? posts.filter((p) => p.data.status === 'published')
-		: posts;
+	const filtered = getVisibleBlogPosts(await getCollection('blog'));
 	return filtered.map((post) => ({
 		params: { slug: post.id },
 		props: post,

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,25 +1,15 @@
 ---
 import { Image } from 'astro:assets';
-import { getCollection } from 'astro:content';
 import BaseHead from '../../components/BaseHead.astro';
 import Footer from '../../components/Footer.astro';
 import FormattedDate from '../../components/FormattedDate.astro';
 import Header from '../../components/Header.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
+import { getVisibleSortedBlogPosts, withBlogThumbs } from '../../lib/blog';
 import { tagToSlug } from '../../lib/slug';
-// Generated SVG thumbnails (lazy) with fallback to default.svg
-const thumbs = import.meta.glob('../../assets/thumbs/*.svg', { query: '?url', import: 'default' }) as Record<string, () => Promise<string>>;
-async function getThumb(id: string): Promise<string> {
-  const key = `../../assets/thumbs/${id}.svg`;
-  const def = `../../assets/thumbs/default.svg`;
-  const loader = thumbs[key] || thumbs[def];
-  return await loader();
-}
 
-const posts = (await getCollection('blog'))
-  .filter((p) => (import.meta.env.PROD ? p.data.status === 'published' : true))
-  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
-const enhanced = await Promise.all(posts.map(async (p) => ({ ...p, thumb: await getThumb(p.id) })));
+const posts = await getVisibleSortedBlogPosts();
+const enhanced = await withBlogThumbs(posts);
 
 // Compute categories with at least one post
 const catCounts = new Map<string, number>();

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -3,32 +3,22 @@ import { getCollection } from 'astro:content';
 import BaseHead from '../../components/BaseHead.astro';
 import Footer from '../../components/Footer.astro';
 import Header from '../../components/Header.astro';
+import { getVisibleBlogPosts, sortBlogPostsByDateDesc, withBlogThumbs } from '../../lib/blog';
 import { tagToSlug } from '../../lib/slug';
 import PostsGrid from '../../components/PostsGrid.astro';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog');
-  const prod = import.meta.env.PROD;
-  const visible = prod ? posts.filter((p) => p.data.status === 'published') : posts;
+  const visible = getVisibleBlogPosts(await getCollection('blog'));
   const cats = new Set<string>();
   for (const p of visible) for (const c of (p.data.categories ?? [])) cats.add(c);
   return [...cats].map((c) => ({ params: { category: tagToSlug(c) }, props: { category: c } }));
 }
 
 const { category } = Astro.props as { category: string };
-const posts = (await getCollection('blog'))
-  .filter((p) => (import.meta.env.PROD ? p.data.status === 'published' : true))
-  .filter((p) => (p.data.categories ?? []).includes(category))
-  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
-
-  const thumbs = import.meta.glob('../../assets/thumbs/*.svg', { query: '?url', import: 'default' }) as Record<string, () => Promise<string>>;
-  async function getThumb(id: string): Promise<string> {
-  const key = `../../assets/thumbs/${id}.svg`;
-  const def = `../../assets/thumbs/default.svg`;
-  const loader = thumbs[key] || thumbs[def];
-  return await loader();
-}
-const enhanced = await Promise.all(posts.map(async (p) => ({ ...p, thumb: await getThumb(p.id) })));
+const posts = sortBlogPostsByDateDesc(
+  getVisibleBlogPosts(await getCollection('blog')).filter((p) => (p.data.categories ?? []).includes(category)),
+);
+const enhanced = await withBlogThumbs(posts);
 ---
 
 <!doctype html>

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -1,11 +1,11 @@
 ---
-import { getCollection } from 'astro:content';
 import BaseHead from '../../components/BaseHead.astro';
 import Footer from '../../components/Footer.astro';
 import Header from '../../components/Header.astro';
+import { getVisibleSortedBlogPosts } from '../../lib/blog';
 import { tagToSlug } from '../../lib/slug';
 
-const posts = (await getCollection('blog')).filter((p) => (import.meta.env.PROD ? p.data.status === 'published' : true));
+const posts = await getVisibleSortedBlogPosts();
 const catCounts = new Map<string, number>();
 for (const p of posts) {
   const cats = Array.isArray(p.data.categories) ? p.data.categories : [];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,28 +3,15 @@ import BaseHead from '../components/BaseHead.astro';
 import Footer from '../components/Footer.astro';
 import Header from '../components/Header.astro';
 import PostsGrid from '../components/PostsGrid.astro';
-import { getCollection } from 'astro:content';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
+import { getVisibleSortedBlogPosts, withBlogThumbs } from '../lib/blog';
 import { tagToSlug } from '../lib/slug';
 import heroTiles from '../assets/patterns/hero-tiles.svg?url';
 import Info from '../components/icons/Info.astro';
 
-// Thumbnails with runtime-safe lazy imports (avoid missing-file crashes in dev)
-const thumbs = import.meta.glob('../assets/thumbs/*.svg', { query: '?url', import: 'default' });
-async function getThumb(id: string) {
-  const key = `../assets/thumbs/${id}.svg`;
-  const def = `../assets/thumbs/default.svg`;
-  const loader = (thumbs as Record<string, () => Promise<string>>)[key] || (thumbs as Record<string, () => Promise<string>>)[def];
-  return await loader();
-}
-
-const allPosts = await getCollection('blog');
-// Respect draft visibility: in production show only published posts; in dev show all
-const posts = allPosts.filter((p) => (import.meta.env.PROD ? p.data.status === 'published' : true));
-const latestPosts = posts
-    .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
-    .slice(0, 8);
-const latestWithThumbs = await Promise.all(latestPosts.map(async (p) => ({ ...p, thumb: await getThumb(p.id) })));
+const posts = await getVisibleSortedBlogPosts();
+const latestPosts = posts.slice(0, 8);
+const latestWithThumbs = await withBlogThumbs(latestPosts);
 
 // Compute tag cloud data
 const tagCounts = new Map<string, number>();

--- a/src/pages/search.json.ts
+++ b/src/pages/search.json.ts
@@ -1,10 +1,8 @@
 import { getCollection } from 'astro:content';
+import { getVisibleBlogPosts, sortBlogPostsByDateDesc } from '../lib/blog';
 
 export async function GET() {
-  const all = await getCollection('blog');
-  const posts = all.filter((p) => (import.meta.env.PROD ? p.data.status === 'published' : true));
-  const blogItems = posts
-    .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+  const blogItems = sortBlogPostsByDateDesc(getVisibleBlogPosts(await getCollection('blog')))
     .map((p) => ({
       type: 'post' as const,
       id: p.id,

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -3,33 +3,22 @@ import { type CollectionEntry, getCollection } from 'astro:content';
 import BaseHead from '../../components/BaseHead.astro';
 import Footer from '../../components/Footer.astro';
 import Header from '../../components/Header.astro';
+import { getVisibleBlogPosts, sortBlogPostsByDateDesc, withBlogThumbs } from '../../lib/blog';
 import { tagToSlug } from '../../lib/slug';
 import PostsGrid from '../../components/PostsGrid.astro';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog');
-  const prod = import.meta.env.PROD;
-  const visible = prod ? posts.filter((p) => p.data.status === 'published') : posts;
+  const visible = getVisibleBlogPosts(await getCollection('blog'));
   const tags = new Set<string>();
   for (const p of visible) for (const t of (p.data.tags ?? [])) tags.add(t);
   return [...tags].map((t) => ({ params: { tag: tagToSlug(t) }, props: { tag: t } }));
 }
 
 const { tag } = Astro.props as { tag: string };
-const posts = (await getCollection('blog'))
-  .filter((p) => (import.meta.env.PROD ? p.data.status === 'published' : true))
-  .filter((p) => (p.data.tags ?? []).includes(tag))
-  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
-
-// Thumbnails with lazy import and fallback to default.svg
-const thumbs = import.meta.glob('../../assets/thumbs/*.svg', { query: '?url', import: 'default' });
-async function getThumb(id: string) {
-  const key = `../../assets/thumbs/${id}.svg`;
-  const def = `../../assets/thumbs/default.svg`;
-  const loader = (thumbs as Record<string, () => Promise<string>>)[key] || (thumbs as Record<string, () => Promise<string>>)[def];
-  return await loader();
-}
-const enhanced = await Promise.all(posts.map(async (p) => ({ ...p, thumb: await getThumb(p.id) })));
+const posts = sortBlogPostsByDateDesc(
+  getVisibleBlogPosts(await getCollection('blog')).filter((p) => (p.data.tags ?? []).includes(tag)),
+);
+const enhanced = await withBlogThumbs(posts);
 ---
 
 <!doctype html>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,11 +1,11 @@
 ---
-import { getCollection } from 'astro:content';
 import BaseHead from '../../components/BaseHead.astro';
 import Footer from '../../components/Footer.astro';
 import Header from '../../components/Header.astro';
+import { getVisibleSortedBlogPosts } from '../../lib/blog';
 import { tagToSlug } from '../../lib/slug';
 
-const posts = (await getCollection('blog')).filter((p) => (import.meta.env.PROD ? p.data.status === 'published' : true));
+const posts = await getVisibleSortedBlogPosts();
 const tagCounts = new Map<string, number>();
 for (const p of posts) {
   const tags = Array.isArray(p.data.tags) ? p.data.tags : [];


### PR DESCRIPTION
Key Changes
Issue 2: duplicated blog visibility, sorting, and thumbnails

Add a small shared blog utility module, for example src/lib/blog.ts.
Move these behaviors into helpers:
get visible blog posts with the existing draft rule: production shows only published, development shows all
sort posts by pubDate descending
resolve thumbnail URL by post id with fallback to default.svg
Update homepage, blog archive, tag/category pages, 404, and BlogPost prev/next lookup to call those helpers instead of repeating the same logic.
Keep page-specific work local, such as tag/category counting and page layout.
Issue 3: two search index builders

Keep src/pages/search.json.ts as the only search index generator.
Remove the post-build overwrite step from npm run build so the build no longer replaces dist/search.json.
Delete scripts/build-search-index.mjs if it is no longer needed, or stop calling it and leave removal for a separate cleanup commit.
Preserve the current search response shape used by the search UI and 404 search UI: url, title, description, content, tags, pubDate, and type.
If any content currently only comes from the HTML scraper, fold that requirement into the route generator instead of keeping a second builder.
Issue 4: dead code and misleading password-gate config

Remove the unused canonicalURL and resolvedImageWithDomain declarations from src/layouts/Page.astro.
Keep canonical/meta ownership inside BaseHead, since that is already the active SEO entrypoint.
Replace the hardcoded password-gate constant in src/components/BaseHead.astro with an env-based boolean derived from PUBLIC_ENABLE_PASSWORD_GATE.
Update the nearby comments so they match the real behavior.
Keep the existing behavior unchanged when the env var is absent: gate stays off.